### PR TITLE
sddm: Use wayland as default

### DIFF
--- a/etc/sddm.conf.d/01-wayland.conf
+++ b/etc/sddm.conf.d/01-wayland.conf
@@ -1,0 +1,6 @@
+[General]
+DisplayServer=wayland
+GreeterEnvironment=QT_WAYLAND_SHELL_INTEGRATION=layer-shell
+
+[Wayland]
+CompositorCommand=kwin_wayland --drm --no-lockscreen --no-global-shortcuts --locale1


### PR DESCRIPTION
This makes sddm use wayland as default.
The main benefits are, that the Refresh Rate is set to the highest one available, also it appears using Plasma 6.2 beta results into a broken sddm.

The main issue comes, that people with:
- 390xx
- 470xx

Drivers will have issue's using that. We should might put a wiki entry for these cases.