### PR TITLE
Enable NumLock by default.

### DIFF
--- a/etc/skel/.config/kcminputrc
+++ b/etc/skel/.config/kcminputrc
@@ -1,2 +1,5 @@
 [Mouse]
 cursorTheme=capitaine-cursors
+
+[Keyboard]
+NumLock=0


### PR DESCRIPTION
This ensures NumLock is enabled by default on startup.